### PR TITLE
Make all types readonly

### DIFF
--- a/src/data-access/users.ts
+++ b/src/data-access/users.ts
@@ -113,7 +113,7 @@ export async function removeUser(payId: string): Promise<void> {
 // HELPER FUNCTIONS
 
 interface DatabaseAddress extends AddressInformation {
-  accountId: string
+  readonly accountId: string
 }
 
 /**

--- a/src/services/headers.ts
+++ b/src/services/headers.ts
@@ -8,15 +8,20 @@ const badAcceptHeaderErrorMessage = `Must have an Accept header of the form "app
       - 'Accept: application/payid+json'
       `
 
-/** A parsed accept header object. */
+/** A parsed HTTP Accept header object. */
 export interface ParsedAcceptHeader {
-  // A raw media type string
-  mediaType: string
-  // An environment requested in the media type
-  // Optional as some headers (e.g. application/ach+json) don't have an environment
-  environment?: string
-  // A payment network requested in the media type
-  paymentNetwork: string
+  /** A raw Accept header media type. */
+  readonly mediaType: string
+
+  /** The payment network requested in the media type. */
+  readonly paymentNetwork: string
+
+  /**
+   * The environment requested in the media type.
+   *
+   * Optional, as some headers (like application/ach+json) don't have an environment.
+   */
+  readonly environment?: string
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -5,7 +5,7 @@ import { CryptoAddressDetails, AchAddressDetails } from './publicAPI'
  */
 export interface Account {
   readonly id: string
-  payId: string
+  readonly payId: string
 
   readonly createdAt: Date
   readonly updatedAt: Date
@@ -16,11 +16,11 @@ export interface Account {
  */
 export interface Address {
   readonly id: number
-  accountId: string
+  readonly accountId: string
 
-  paymentNetwork: string
-  environment?: string | null
-  details: CryptoAddressDetails | AchAddressDetails
+  readonly paymentNetwork: string
+  readonly environment?: string | null
+  readonly details: CryptoAddressDetails | AchAddressDetails
 
   readonly createdAt: Date
   readonly updatedAt: Date

--- a/src/types/publicAPI.ts
+++ b/src/types/publicAPI.ts
@@ -10,16 +10,16 @@ export enum AddressDetailsType {
  * Matching schema for AddressDetailsType.CryptoAddress.
  */
 export interface CryptoAddressDetails {
-  address: string
-  tag?: string
+  readonly address: string
+  readonly tag?: string
 }
 
 /**
  * Matching schema for AddressDetailsType.AchAddress.
  */
 export interface AchAddressDetails {
-  accountNumber: string
-  routingNumber: string
+  readonly accountNumber: string
+  readonly routingNumber: string
 }
 
 /**
@@ -27,18 +27,18 @@ export interface AchAddressDetails {
  * case of a GET request to the base path /).
  */
 export interface PaymentInformation {
-  addresses: Address[]
-  proofOfControlSignature?: string
-  payId?: string
-  memo?: string
+  readonly addresses: Address[]
+  readonly proofOfControlSignature?: string
+  readonly payId?: string
+  readonly memo?: string
 }
 
 /**
  * Address information included inside of a PaymentInformation object.
  */
 interface Address {
-  paymentNetwork: string
-  environment?: string
-  addressDetailsType: AddressDetailsType
-  addressDetails: CryptoAddressDetails | AchAddressDetails
+  readonly paymentNetwork: string
+  readonly environment?: string
+  readonly addressDetailsType: AddressDetailsType
+  readonly addressDetails: CryptoAddressDetails | AchAddressDetails
 }


### PR DESCRIPTION
## High Level Overview of Change

Make all `interface` properties readonly.

In general, it's best to be explicit about when we expect object mutations and when we don't. We basically never mutate objects in our codebase, and we can enforce that by typing our object properties as `readonly`.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

All interfaces are now `readonly`.

## Test Plan

TypeScript compiles.

<!--
## Future Tasks
For future tasks related to PR.
-->
