### PR TITLE
Remove proof of control signature

### DIFF
--- a/src/types/publicAPI.ts
+++ b/src/types/publicAPI.ts
@@ -28,7 +28,6 @@ export interface AchAddressDetails {
  */
 export interface PaymentInformation {
   addresses: Address[]
-  proofOfControlSignature?: string
   payId?: string
   memo?: string
 }


### PR DESCRIPTION
## High Level Overview of Change

The Proof of Control Signature currently serves no purpose and is unused, so we should remove it.

We may have to add the Proof of Control signature back when we implement travel rule, but for now it serves only to confuse users that look at our code.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Future Tasks
For future tasks related to PR.
-->
