### PR TITLE
Add a report for count of PayIDs

### DIFF
--- a/src/data-access/reports.ts
+++ b/src/data-access/reports.ts
@@ -1,25 +1,39 @@
 import knex from '../db/knex'
-import { PayIdCount } from '../types/reports'
+import { AddressCount } from '../types/reports'
 
 /**
- * Retrieve count of PayIDs, grouped by payment network and environment.
+ * Retrieve count of addresses, grouped by payment network and environment.
  *
- * @returns A list with the number of PayIDs that have a given (paymentNetwork, environment) tuple,
+ * @returns A list with the number of addresses that have a given (paymentNetwork, environment) tuple,
  *          ordered by (paymentNetwork, environment).
  */
-export default async function getPayIdCounts(): Promise<PayIdCount[]> {
-  const payIdCounts: PayIdCount[] = await knex
+export async function getAddressCounts(): Promise<AddressCount[]> {
+  const addressCounts: AddressCount[] = await knex
     .select('address.paymentNetwork', 'address.environment')
     .count('* as count')
-    .from<PayIdCount>('address')
+    .from<AddressCount>('address')
     .groupBy('address.paymentNetwork', 'address.environment')
     .orderBy(['address.paymentNetwork', 'address.environment'])
 
-  return payIdCounts.map((record) => {
-    return {
-      paymentNetwork: record.paymentNetwork,
-      environment: record.environment,
-      count: Number(record.count),
-    }
-  })
+  return addressCounts.map((addressCount) => ({
+    paymentNetwork: addressCount.paymentNetwork,
+    environment: addressCount.environment,
+    count: Number(addressCount.count),
+  }))
+}
+
+/**
+ * Retrieve the count of PayIDs in the database.
+ *
+ * @returns The count of PayIDs that exist for this PayID server.
+ */
+export async function getPayIdCount(): Promise<number> {
+  const payIdCount: number = await knex
+    .count('* as count')
+    .from<Account>('account')
+    .then((record) => {
+      return Number(record[0].count)
+    })
+
+  return payIdCount
 }

--- a/src/types/reports.ts
+++ b/src/types/reports.ts
@@ -1,7 +1,7 @@
 /**
- * Query result record for a count of PayIDs by environment and paymentNetwork.
+ * Query result record for a count of addresses by environment and paymentNetwork.
  */
-export interface PayIdCount {
+export interface AddressCount {
   paymentNetwork: string
   environment: string
   count: number

--- a/test/integration/data-access/reports.test.ts
+++ b/test/integration/data-access/reports.test.ts
@@ -1,7 +1,10 @@
 import 'mocha'
 import { assert } from 'chai'
 
-import getPayIdCounts from '../../../src/data-access/reports'
+import {
+  getAddressCounts,
+  getPayIdCount,
+} from '../../../src/data-access/reports'
 import { seedDatabase } from '../../helpers/helpers'
 
 describe('Data Access - getPayIdCounts()', function (): void {
@@ -9,8 +12,8 @@ describe('Data Access - getPayIdCounts()', function (): void {
     await seedDatabase()
   })
 
-  it('Returns a result per by unique network and environment', async function () {
-    const results = await getPayIdCounts()
+  it('getAddressCounts - Returns a result per by unique network and environment', async function () {
+    const results = await getAddressCounts()
     const expected = [
       {
         paymentNetwork: 'ACH',
@@ -39,5 +42,12 @@ describe('Data Access - getPayIdCounts()', function (): void {
       },
     ]
     assert.deepEqual(results, expected)
+  })
+
+  it('getPayIdCount - Returns a count of PayIDs', async function () {
+    const payIdCount = await getPayIdCount()
+    const expectedPayIdCount = 5
+
+    assert.strictEqual(payIdCount, expectedPayIdCount)
   })
 })

--- a/test/integration/e2e/admin-api/metrics.test.ts
+++ b/test/integration/e2e/admin-api/metrics.test.ts
@@ -79,19 +79,28 @@ describe('E2E - adminApiRouter - GET /metrics', function (): void {
     )
   })
 
-  it('Includes count of all PayIDs', async function () {
+  it('Includes count of all addresses', async function () {
     const achNetwork = 'ACH'
     const litecoinNetwork = 'LTC'
     await createPayId('charlie$fightmilk.com', achNetwork, 'US')
     await createPayId('mac$fightmilk.com', achNetwork, 'US')
     await createPayId('frank$wolfcola.com', litecoinNetwork, 'MAINNET')
-    await metrics.generatePayIdCountMetrics()
+    await metrics.generateAddressCountMetrics()
+
     await assertMetrics(
       /payid_count\{paymentNetwork="ACH",environment="US",org="127.0.0.1"\} 2/u,
     )
     await assertMetrics(
       /payid_count\{paymentNetwork="LTC",environment="MAINNET",org="127.0.0.1"\} 1/u,
     )
+  })
+
+  it('Includes count of all PayIDs', async function () {
+    await metrics.generatePayIdCountMetrics()
+
+    // We create 8 PayIDs in the tests before this one,
+    // and start with 5 seeded PayIDs, for a total of 13.
+    await assertMetrics(/actual_payid_count\{org="127.0.0.1"\} 13/u)
   })
 
   /**


### PR DESCRIPTION
## High Level Overview of Change

Adds a report for the count of the number of PayIDs.

Also rename the existing report logic to reflect that it is actually a count of addresses.

### Context of Change

We currently only capture a count of addresses grouped by `(paymentNetwork, environment)`, but it can be misleading if you think that is a count of unique PayIDs. Now, we have a separate Prometheus Gauge that counts up the number of unique PayIDs per server.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Added some relevant tests and `npm run test` is green.

<!--
## Future Tasks
For future tasks related to PR.
-->
