### PR TITLE
Cut the v-prepend from the Git version

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -53,7 +53,7 @@ compare_versions() {
    eval $(parse_yaml docker-compose.yml "config_")
    declare -r docker_image_version=$(echo $config_services_payid_server_image | cut -f 2 -d ':')
    declare -r npm_version=$1
-   declare -r git_tag_version=$(git describe --tags | cut -f 1 -d '-')
+   declare -r git_tag_version=$(git describe --tags | cut -f 1 -d '-' | cut -c 2-)
 
    if [[ $docker_image_version != $npm_version || \
          $docker_image_version != $git_tag_version || \


### PR DESCRIPTION
## High Level Overview of Change

Our git tags are in the form `vX.Y.Z`, but our `package.json` version is in the form `X.Y.Z`, thus, to compare them, we need to cut the v-prefix from our git tag version.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

I can now run `npm run compareVersions` and it works correctly.
