### PR TITLE
Fix payid+json incorrect 200 error

### DIFF
--- a/src/middlewares/payIds.ts
+++ b/src/middlewares/payIds.ts
@@ -53,17 +53,7 @@ export default async function getPaymentInfo(
   // TODO:(hbergren) Distinguish between missing PayID in system, and missing address for paymentNetwork/environment.
   // Respond with a 404 if we can't find the requested payment information
   if (preferredAddressInfo === undefined) {
-    let message = `Payment information for ${payId} could not be found.`
-    // When we only have a single accept type, we can give a more detailed error message
-    if (parsedAcceptHeaders.length === 1) {
-      const { paymentNetwork, environment } = parsedAcceptHeaders[0]
-      message = `Payment information for ${payId} in ${paymentNetwork} `
-      // eslint-disable-next-line max-depth -- TODO:(@dino-rodriguez) This should be refactored
-      if (environment) {
-        message += `on ${environment} `
-      }
-      message += 'could not be found.'
-    }
+    // Record metrics for 404s
     parsedAcceptHeaders.forEach((acceptType) =>
       metrics.recordPayIdLookupResult(
         false,
@@ -72,7 +62,10 @@ export default async function getPaymentInfo(
       ),
     )
 
-    throw new LookupError(message, LookupErrorType.Unknown)
+    throw new LookupError(
+      `Payment information for ${payId} could not be found.`,
+      LookupErrorType.Unknown,
+    )
   }
 
   const {

--- a/src/services/basePayId.ts
+++ b/src/services/basePayId.ts
@@ -57,6 +57,10 @@ export function getPreferredAddressHeaderPair(
       preferredAddresses: readonly AddressInformation[]
     }
   | undefined {
+  if (allAddresses.length === 0) {
+    return undefined
+  }
+
   // Find the optimal payment information from a sorted list
   for (const acceptHeader of sortedParsedAcceptHeaders) {
     // Return all addresses for application/payid+json

--- a/test/integration/e2e/public-api/basePayId.test.ts
+++ b/test/integration/e2e/public-api/basePayId.test.ts
@@ -147,8 +147,7 @@ describe('E2E - publicAPIRouter - Base PayID', function (): void {
     const expectedErrorResponse = {
       statusCode: 404,
       error: 'Not Found',
-      message:
-        'Payment information for johndoe$127.0.0.1 in XRPL on TESTNET could not be found.',
+      message: 'Payment information for johndoe$127.0.0.1 could not be found.',
     }
 
     // WHEN we make a GET request to the public endpoint to retrieve payment info with an Accept header specifying xrpl-testnet
@@ -161,15 +160,14 @@ describe('E2E - publicAPIRouter - Base PayID', function (): void {
       .expect(HttpStatus.NotFound, expectedErrorResponse, done)
   })
 
-  it('Returns a 404 for an PayID without the relevant associated address', function (done): void {
+  it('Returns a 404 for a PayID without the relevant associated address', function (done): void {
     // GIVEN a known PayID that exists but does not have an associated devnet XRP address
     const payId = '/alice'
     const acceptHeader = 'application/xrpl-devnet+json'
     const expectedErrorResponse = {
       statusCode: 404,
       error: 'Not Found',
-      message:
-        'Payment information for alice$127.0.0.1 in XRPL on DEVNET could not be found.',
+      message: 'Payment information for alice$127.0.0.1 could not be found.',
     }
 
     // WHEN we make a GET request to the public endpoint to retrieve payment info with an Accept header specifying xrpl-devnet
@@ -180,6 +178,26 @@ describe('E2E - publicAPIRouter - Base PayID', function (): void {
       .expect('Content-Type', /application\/json/u)
       // THEN we get back a 404 with the expected error response.
       .expect(HttpStatus.NotFound, expectedErrorResponse, done)
+  })
+
+  it('Returns a 404 for a PayID request with payid+json, when that PayID has been deleted', function (done): void {
+    // GIVEN a PayID known not to exist
+    const payId = '/johndoe'
+    const acceptHeader = 'application/payid+json'
+    const expectedErrorResponse = {
+      statusCode: 404,
+      error: 'Not Found',
+      message: 'Payment information for johndoe$127.0.0.1 could not be found.',
+    }
+
+    // WHEN we request all addresses for that PayID
+    request(app.publicApiExpress)
+      .get(payId)
+      .set('PayID-Version', '1.0')
+      .set('Accept', acceptHeader)
+      // THEN we get back a 404 with the expected error response.
+      .expect(HttpStatus.NotFound, expectedErrorResponse, done)
+    // })
   })
 
   // Shut down Express application and close DB connections


### PR DESCRIPTION
## High Level Overview of Change

Fix bug in header processing logic, and remove needlessly complex logic for the "Not Found" message we provide.

### Context of Change

There was a bug in our header processing logic, which, if you requested `payid+json` to a non-existent PayID would respond with a `200 - OK`, claiming that PayID existed with no addresses, rather than responding with a `404 - Not Found`.

Relevant issue: https://github.com/payid-org/payid/issues/595

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Added a test for the `payid+json` to a nonexistent PayID case, and it now passes (would fail on `master`).

<!--
## Future Tasks
For future tasks related to PR.
-->
