### PR TITLE
Refactor Admin API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,11 +1777,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/src/middlewares/adminApiHeaders.ts
+++ b/src/middlewares/adminApiHeaders.ts
@@ -14,7 +14,7 @@ import { ParseError, ParseErrorType, ContentTypeError } from '../utils/errors'
  *
  * @throws A ParseError if the PayID-API-Version header is missing, malformed, or unsupported.
  */
-export function checkAdminApiVersionHeaders(
+export function checkRequestAdminApiVersionHeaders(
   req: Request,
   res: Response,
   next: NextFunction,
@@ -65,7 +65,7 @@ export function checkAdminApiVersionHeaders(
  * @param next - An Express next() function.
  * @throws A ParseError if the Content-Type header is missing, malformed, or unsupported.
  */
-export function checkContentType(
+export function checkRequestContentType(
   req: Request,
   _res: Response,
   next: NextFunction,
@@ -104,7 +104,7 @@ export function checkContentType(
  * @param res - An Express Response object.
  * @param next - An Express next() function.
  */
-export function addAcceptPatchHeader(
+export function addAcceptPatchResponseHeader(
   _req: Request,
   res: Response,
   next: NextFunction,
@@ -115,30 +115,6 @@ export function addAcceptPatchHeader(
    * The Accept-Patch response HTTP header advertises which media-type the server is able to understand for a PATCH request.
    */
   res.header('Accept-Patch', 'application/merge-patch+json')
-
-  next()
-}
-
-/**
- * A middleware adding an Allow header in the response.
- *
- * @param _req - An Express Request object. Unused parameters can be conventionally underscored to avoid the check.
- * @param res - An Express Response object.
- * @param next - An Express next() function.
- */
-export function addAllowHeader(
-  _req: Request,
-  res: Response,
-  next: NextFunction,
-): void {
-  /**
-   * Add this header to all responses. Advertising Support in OPTIONS.
-   * A server can advertise its support for the PATCH method by adding it to the listing of allowed methods in the
-   * "Allow" OPTIONS response header defined in HTTP/1.1.  The PATCH method MAY appear in the "Allow" header
-   * even if the Accept-Patch header is absent, in which case the list of allowed patch documents is not advertised.
-   * Https://tools.ietf.org/html/rfc5789#section-3.
-   */
-  res.header('Allow', 'GET, PUT, OPTIONS, DELETE, PATCH')
 
   next()
 }

--- a/src/middlewares/users.ts
+++ b/src/middlewares/users.ts
@@ -33,7 +33,7 @@ export async function getUser(
   next: NextFunction,
 ): Promise<void> {
   // TODO:(dino) Validate PayID
-  const payId = req.params[0].toLowerCase()
+  const payId = req.params.payId.toLowerCase()
 
   // TODO:(hbergren) More validation? Assert that the PayID is `https://` and of a certain form?
   // Could use a similar regex to the one used by the database.
@@ -121,7 +121,7 @@ export async function putUser(
 ): Promise<void> {
   // TODO:(hbergren) Validate req.body and throw a 400 Bad Request when appropriate
   // TODO(hbergren): pull this PayID / HttpError out into middleware?
-  const rawPayId = req.params[0]
+  const rawPayId = req.params.payId
   const rawNewPayId = req.body?.payId
   const addresses = req.body?.addresses
 
@@ -203,7 +203,7 @@ export async function deleteUser(
   next: NextFunction,
 ): Promise<void> {
   // TODO:(hbergren) This absolutely needs to live in middleware
-  const payId = req.params[0].toLowerCase()
+  const payId = req.params.payId.toLowerCase()
 
   // TODO:(hbergren) More validation? Assert that the PayID is `https://` and of a certain form?
   // Do that using a regex route param in Express? Could use a similar regex to the one used by the database.

--- a/src/routes/adminApiRouter.ts
+++ b/src/routes/adminApiRouter.ts
@@ -1,10 +1,9 @@
 import * as express from 'express'
 
 import {
-  checkAdminApiVersionHeaders,
-  checkContentType,
-  addAcceptPatchHeader,
-  addAllowHeader,
+  checkRequestAdminApiVersionHeaders,
+  checkRequestContentType,
+  addAcceptPatchResponseHeader,
 } from '../middlewares/adminApiHeaders'
 import errorHandler, { wrapAsync } from '../middlewares/errorHandler'
 import sendSuccess from '../middlewares/sendSuccess'
@@ -22,61 +21,41 @@ const adminApiRouter = express.Router()
  * Routes for the PayID Admin API.
  */
 adminApiRouter
-  // Options user PayID route
-  .options(
-    '/:payId',
-    addAllowHeader,
-    addAcceptPatchHeader,
-    checkAdminApiVersionHeaders,
-    sendSuccess,
-  )
+  // All /:payId requests should have an Accept-Patch response header with the PATCH mime type
+  .use('/:payId', addAcceptPatchResponseHeader)
+
+  // All [POST, PUT, PATCH] requests should have an appropriate Content-Type header,
+  // AND all Admin API requests should have an appropriate PayID-API-Version header.
+  .use('/*', checkRequestContentType, checkRequestAdminApiVersionHeaders)
 
   // Get user route
-  .get(
-    '/*',
-    addAcceptPatchHeader,
-    checkAdminApiVersionHeaders,
-    wrapAsync(getUser),
-    sendSuccess,
-  )
+  .get('/:payId', wrapAsync(getUser), sendSuccess)
 
   // Create user route
   .post(
     '/',
     express.json(),
-    checkAdminApiVersionHeaders,
-    // TODO => checkContentType + E2E tests,
+    // TODO:(hbergren) checkRequestContentType E2E tests,
     wrapAsync(postUser),
     sendSuccess,
   )
 
   // Replace user route
   .put(
-    '/*',
+    '/:payId',
     express.json(),
-    addAcceptPatchHeader,
-    checkAdminApiVersionHeaders,
-    // TODO => checkContentType + E2E tests,
+    // TODO:(hbergren) checkRequestContentType E2E tests,
     wrapAsync(putUser),
     sendSuccess,
   )
 
   // Delete user route
-  .delete(
-    '/*',
-    addAcceptPatchHeader,
-    checkAdminApiVersionHeaders,
-    wrapAsync(deleteUser),
-    sendSuccess,
-  )
+  .delete('/:payId', wrapAsync(deleteUser), sendSuccess)
 
-  // Patch user PayID route
+  // Patch user's PayID route
   .patch(
     '/:payId',
     express.json({ type: 'application/merge-patch+json' }),
-    addAcceptPatchHeader,
-    checkAdminApiVersionHeaders,
-    checkContentType,
     wrapAsync(patchUserPayId),
     sendSuccess,
   )

--- a/test/integration/e2e/admin-api/optionsUsersPayId.test.ts
+++ b/test/integration/e2e/admin-api/optionsUsersPayId.test.ts
@@ -16,19 +16,28 @@ describe('E2E - adminApiRouter - OPTIONS /users/:payId', function (): void {
     app = await appSetup()
   })
 
-  it('Returns a 200 with the Allow header', function (done): void {
+  it('Returns a 200 with PATCH in the Allow header', function (done): void {
     // GIVEN a PayID known to resolve to an account on the PayID service
     const payId = 'alice$xpring.money'
-    // AND the Allow header expected
-    const allowHeader = 'GET, PUT, OPTIONS, DELETE, PATCH'
 
     // WHEN we make an OPTIONS request to /users/:payId
     request(app.adminApiExpress)
       .options(`/users/${payId}`)
       .set('PayID-API-Version', payIdApiVersion)
-      .expect('Content-Type', /text\/plain/u)
       // THEN we expect the Allow header in the response
-      .expect('Allow', allowHeader)
+      .expect('Allow', /PATCH/u)
+      // AND we expect back a 200-OK
+      .expect(HttpStatus.OK, done)
+  })
+
+  it('Returns a 200 with the appropriate Accept-Patch response header', function (done): void {
+    // GIVEN a PayID known to resolve to an account on the PayID service
+    const payId = 'alice$xpring.money'
+
+    // WHEN we make an OPTIONS request to /users/:payId
+    request(app.adminApiExpress)
+      .options(`/users/${payId}`)
+      .set('PayID-API-Version', payIdApiVersion)
       // THEN we expect the Accept-Patch header in the response
       .expect('Accept-Patch', contentType)
       // AND we expect back a 200-OK
@@ -38,10 +47,6 @@ describe('E2E - adminApiRouter - OPTIONS /users/:payId', function (): void {
   it('Returns a 400 - the PayID-API-Version header is missing', function (done): void {
     // GIVEN a PayID known to resolve to an account on the PayID service
     const payId = 'alice$xpring.money'
-
-    // AND the expected Allow header
-    const allowHeader = 'GET, PUT, OPTIONS, DELETE, PATCH'
-
     // AND our expected error response
     const expectedErrorResponse = {
       error: 'Bad Request',
@@ -55,11 +60,9 @@ describe('E2E - adminApiRouter - OPTIONS /users/:payId', function (): void {
       .options(`/users/${payId}`)
       // WITHOUT the 'PayID-API-Version' header
       .expect('Content-Type', /json/u)
-      // THEN we expect the Allow header in the response
-      .expect('Allow', allowHeader)
       // THEN we expect the Accept-Patch header in the response
       .expect('Accept-Patch', contentType)
-      // THEN we expect back a 400 - Bad Request
+      // AND we expect back a 400 - Bad Request
       .expect(HttpStatus.BadRequest, expectedErrorResponse, done)
   })
 


### PR DESCRIPTION
## High Level Overview of Change

Just some follow-on refactors after Florent's PATCH PR.

We:
- Remove the custom `.options()` routes
- Explicitly define our user routes as `/:payId` rather than `/*`
- Correctly use Express `.use()` functions to check request headers and create response headers that need to be on multiple request endpoints, rather than duplicating the middleware functions inside the routes.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

npm run test is still green.

<!--
## Future Tasks
For future tasks related to PR.
-->
