### PR TITLE
wrapAsync constructJrd call so error comes back correctly and bad req…

### DIFF
--- a/src/middlewares/constructJrd.ts
+++ b/src/middlewares/constructJrd.ts
@@ -25,7 +25,7 @@ export default async function constructJrd(
   // check for that here.
   if (!payId || Array.isArray(payId) || typeof payId !== 'string') {
     throw new ParseError(
-      'A `payId` must be provided in the resource request parameter.',
+      'A PayID must be provided in the `resource` request parameter.',
       ParseErrorType.MissingPayId,
     )
   }

--- a/src/middlewares/constructJrd.ts
+++ b/src/middlewares/constructJrd.ts
@@ -13,11 +13,11 @@ import { ParseError, ParseErrorType } from '../utils/errors'
  * @returns A Promise resolving to nothing.
  * @throws ParseError if the PayID is missing from the request parameters.
  */
-export default async function constructJrd(
+export default function constructJrd(
   req: Request,
   res: Response,
   next: NextFunction,
-): Promise<void> {
+): void {
   const payId = req.query.resource
 
   // Query parameters could be a string or a ParsedQs, or an array of either.

--- a/src/routes/publicApiRouter.ts
+++ b/src/routes/publicApiRouter.ts
@@ -41,7 +41,7 @@ publicApiRouter
   .get('/status/health', sendSuccess)
 
   // PayID Discovery route
-  .get('/.well-known/webfinger', constructJrd, sendSuccess)
+  .get('/.well-known/webfinger', wrapAsync(constructJrd), sendSuccess)
 
   // Base PayID route
   .get(

--- a/src/routes/publicApiRouter.ts
+++ b/src/routes/publicApiRouter.ts
@@ -41,7 +41,7 @@ publicApiRouter
   .get('/status/health', sendSuccess)
 
   // PayID Discovery route
-  .get('/.well-known/webfinger', wrapAsync(constructJrd), sendSuccess)
+  .get('/.well-known/webfinger', constructJrd, sendSuccess)
 
   // Base PayID route
   .get(


### PR DESCRIPTION
## High Level Overview of Change
* Improve error message in `constructJrd` middleware
* Made `constructJrd()` not async
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
`constructJrd` used to be an async function because originally I was parsing the `discoveryLinks.json` file using `fs.promises.readFile`, which is an async function.  Now that we are importing the file as a ts module, this function doesn't need to be async.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
`constructJrd` was async, now it is not
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
E2E testing for this endpoint coming in following PR.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
