### PR TITLE
Add E2E Tests for Discovery Endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,11 +1777,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/test/integration/e2e/public-api/discovery.test.ts
+++ b/test/integration/e2e/public-api/discovery.test.ts
@@ -1,0 +1,32 @@
+import HttpStatus from '@xpring-eng/http-status'
+import * as request from 'supertest'
+
+import App from '../../../../src/app'
+import { appSetup } from '../../../helpers/helpers'
+
+// eslint-disable-next-line node/file-extension-in-import -- typescript needs .json extension
+import * as discoveryLinks from './testDiscoveryLinks.json'
+
+let app: App
+
+describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
+  // Boot up Express application and initialize DB connection pool
+  before(async function () {
+    app = await appSetup()
+  })
+
+  it('Discovery query returns JRD', function (done): void {
+    // GIVEN a PayID
+    const payId = 'alice$wallet.com'
+    const expectedResponse = {
+      subject: payId,
+      discoveryLinks,
+    }
+
+    // WHEN we make a GET request to the PayID Discovery endpoint
+    request(app.publicApiExpress)
+      .get(`/.well-known/webfinger?resource=${payId}`)
+      // THEN we get back a JRD with subject = the PayID and all links from the discoveryLinks.json file
+      .expect(HttpStatus.OK, expectedResponse, done)
+  })
+})

--- a/test/integration/e2e/public-api/discovery.test.ts
+++ b/test/integration/e2e/public-api/discovery.test.ts
@@ -16,10 +16,6 @@ describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
     app = await appSetup()
   })
 
-  after(function () {
-    appCleanup(app)
-  })
-
   it('Discovery query returns JRD', function (done): void {
     // GIVEN a PayID
     const payId = 'alice$wallet.com'
@@ -48,5 +44,9 @@ describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
       .get(discoveryPath)
       // THEN we get back a 400 with the expected error message
       .expect(HttpStatus.BadRequest, expectedErrorResponse, done)
+  })
+
+  after(function () {
+    appCleanup(app)
   })
 })

--- a/test/integration/e2e/public-api/discovery.test.ts
+++ b/test/integration/e2e/public-api/discovery.test.ts
@@ -8,13 +8,12 @@ import { appCleanup, appSetup } from '../../../helpers/helpers'
 import * as discoveryLinks from './testDiscoveryLinks.json'
 
 let app: App
-let discoveryPath: string
+const discoveryPath = '/.well-known/webfinger'
 
 describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
   // Boot up Express application and initialize DB connection pool
   before(async function () {
     app = await appSetup()
-    discoveryPath = '/.well-known/webfinger'
   })
 
   after(function () {

--- a/test/integration/e2e/public-api/discovery.test.ts
+++ b/test/integration/e2e/public-api/discovery.test.ts
@@ -8,11 +8,13 @@ import { appCleanup, appSetup } from '../../../helpers/helpers'
 import * as discoveryLinks from './testDiscoveryLinks.json'
 
 let app: App
+let discoveryPath: string
 
 describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
   // Boot up Express application and initialize DB connection pool
   before(async function () {
     app = await appSetup()
+    discoveryPath = '/.well-known/webfinger'
   })
 
   after(function () {
@@ -29,7 +31,7 @@ describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
 
     // WHEN we make a GET request to the PayID Discovery endpoint
     request(app.publicApiExpress)
-      .get(`/.well-known/webfinger?resource=${payId}`)
+      .get(`${discoveryPath}?resource=${payId}`)
       // THEN we get back a JRD with subject = the PayID and all links from the discoveryLinks.json file
       .expect(HttpStatus.OK, expectedResponse, done)
   })
@@ -44,7 +46,7 @@ describe('E2E - publicAPIRouter - PayID Discovery', function (): void {
 
     // WHEN we make a GET request to the PayID Discovery endpoint with no `resource` request parameter
     request(app.publicApiExpress)
-      .get('/.well-known/webfinger')
+      .get(discoveryPath)
       // THEN we get back a 400 with the expected error message
       .expect(HttpStatus.BadRequest, expectedErrorResponse, done)
   })

--- a/test/integration/e2e/public-api/testDiscoveryLinks.json
+++ b/test/integration/e2e/public-api/testDiscoveryLinks.json
@@ -1,0 +1,6 @@
+[
+  {
+    "rel": "https://payid.org/ns/payid-easy-checkout/1.0",
+    "template": "https://dev.wallet.xpring.io/wallet/xrp/testnet/payto?receiverPayId={receiverPayId}&amount={amount}&nextUrl={nextUrl}?easyCheckoutSuccess=true"
+  }
+]


### PR DESCRIPTION
## High Level Overview of Change
* Adds two E2E integration tests to test PayID Discovery endpoint
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
The `.well-known/webfinger` endpoint was previously untested.  Since the middleware is so lightweight, it doesn't really make sense to break things out into a service to unit test, and because middleware is so difficult to test, these e2e tests should suffice.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
No test coverage for Discovery -> integration test coverage for Discovery
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
N/A
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
