### PR TITLE
Fix Admin API Put for empty addresses

### DIFF
--- a/src/data-access/users.ts
+++ b/src/data-access/users.ts
@@ -195,6 +195,10 @@ async function insertAddresses(
   addresses: readonly DatabaseAddress[],
   transaction: Transaction,
 ): Promise<readonly AddressInformation[]> {
+  if (addresses.length === 0) {
+    return []
+  }
+
   // TODO:(hbergren) Verify that the number of inserted addresses matches the input address array length?
   return knex
     .insert(addresses)

--- a/test/integration/e2e/admin-api/putUsers.test.ts
+++ b/test/integration/e2e/admin-api/putUsers.test.ts
@@ -65,6 +65,24 @@ describe('E2E - adminApiRouter - PUT /users', function (): void {
       .expect(HttpStatus.OK, updatedInformation, done)
   })
 
+  it('Returns a 200 and updated user payload when removing all addresses', function (done): void {
+    // GIVEN a PayID known to resolve to an account on the PayID service
+    const payId = 'empty$xpring.money'
+    const updatedInformation = {
+      payId: 'empty$xpring.money',
+      addresses: [],
+    }
+
+    // WHEN we make a PUT request to /users/ with the new information to update
+    request(app.adminApiExpress)
+      .put(`/users/${payId}`)
+      .set('PayID-API-Version', payIdApiVersion)
+      .send(updatedInformation)
+      .expect('Content-Type', /json/u)
+      // THEN we expect back a 200-OK, with the updated user information
+      .expect(HttpStatus.OK, updatedInformation, done)
+  })
+
   it('Returns a 201 and inserted user payload for a Admin API PUT creating a new user', function (done): void {
     // GIVEN a PayID known to not exist on the PayID service
     const payId = 'notjohndoe$xpring.money'


### PR DESCRIPTION
## High Level Overview of Change

Give the correct response payload when someone makes a PUT request that removes all addresses from our PayID.

### Context of Change

Previously, if you PUT a PayID with an empty address array, you would get this nonsense response:

```json
{
    "payId": "alice$127.0.0.1",
    "addresses": {
        "command": null,
        "rowCount": null,
        "oid": null,
        "rows": [],
        "fields": [],
        "types": {
            "_types": {
                "arrayParser": {},
                "builtins": {
                    "BOOL": 16,
                    "BYTEA": 17,
                    "CHAR": 18,
                    "INT8": 20,
                    "INT2": 21,
                    "INT4": 23,
                    "REGPROC": 24,
                    "TEXT": 25,
                    "OID": 26,
                    "TID": 27,
                    "XID": 28,
                    "CID": 29,
                    "JSON": 114,
                    "XML": 142,
                    "PG_NODE_TREE": 194,
                    "SMGR": 210,
                    "PATH": 602,
                    "POLYGON": 604,
                    "CIDR": 650,
                    "FLOAT4": 700,
                    "FLOAT8": 701,
                    "ABSTIME": 702,
                    "RELTIME": 703,
                    "TINTERVAL": 704,
                    "CIRCLE": 718,
                    "MACADDR8": 774,
                    "MONEY": 790,
                    "MACADDR": 829,
                    "INET": 869,
                    "ACLITEM": 1033,
                    "BPCHAR": 1042,
                    "VARCHAR": 1043,
                    "DATE": 1082,
                    "TIME": 1083,
                    "TIMESTAMP": 1114,
                    "TIMESTAMPTZ": 1184,
                    "INTERVAL": 1186,
                    "TIMETZ": 1266,
                    "BIT": 1560,
                    "VARBIT": 1562,
                    "NUMERIC": 1700,
                    "REFCURSOR": 1790,
                    "REGPROCEDURE": 2202,
                    "REGOPER": 2203,
                    "REGOPERATOR": 2204,
                    "REGCLASS": 2205,
                    "REGTYPE": 2206,
                    "UUID": 2950,
                    "TXID_SNAPSHOT": 2970,
                    "PG_LSN": 3220,
                    "PG_NDISTINCT": 3361,
                    "PG_DEPENDENCIES": 3402,
                    "TSVECTOR": 3614,
                    "TSQUERY": 3615,
                    "GTSVECTOR": 3642,
                    "REGCONFIG": 3734,
                    "REGDICTIONARY": 3769,
                    "JSONB": 3802,
                    "REGNAMESPACE": 4089,
                    "REGROLE": 4096
                }
            },
            "text": {},
            "binary": {}
        },
        "rowCtor": null,
        "rowAsArray": false
    }
}
```

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Added a test specifically for this case.

<!--
## Future Tasks
For future tasks related to PR.
-->
