### PR TITLE
feat: make fiat change non-breaking

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export const payIdServerVersions: readonly string[] = ['1.0']
+export const payIdServerVersions: readonly string[] = ['1.0', '1.1']
 export const adminApiVersions: readonly string[] = ['2020-05-28']
 
 /**

--- a/src/middlewares/payIds.ts
+++ b/src/middlewares/payIds.ts
@@ -77,6 +77,7 @@ export default async function getPaymentInfo(
   // * NOTE: To append a memo, MUST set a memo in createMemo()
   const formattedPaymentInfo = formatPaymentInfo(
     preferredAddresses,
+    res.get('PayID-Version'),
     payId,
     createMemo,
   )

--- a/src/services/basePayId.ts
+++ b/src/services/basePayId.ts
@@ -9,14 +9,15 @@ import { ParsedAcceptHeader } from './headers'
  * a Base PayID flow.
  *
  * @param addresses - Array of address information associated with a PayID.
+ * @param version - The PayID protocol response version.
  * @param payId - Optionally include a PayId.
  * @param memoFn - A function, taking an optional PaymentInformation object,
- *                 that returns a string to be used as the memo.
- *
+ * that returns a string to be used as the memo.
  * @returns The formatted PaymentInformation object.
  */
 export function formatPaymentInfo(
   addresses: readonly AddressInformation[],
+  version: string,
   payId?: string,
   memoFn?: (paymentInformation: PaymentInformation) => string,
 ): PaymentInformation {
@@ -25,7 +26,7 @@ export function formatPaymentInfo(
       return {
         paymentNetwork: address.paymentNetwork,
         ...(address.environment && { environment: address.environment }),
-        addressDetailsType: getAddressDetailsType(address),
+        addressDetailsType: getAddressDetailsType(address, version),
         addressDetails: address.details,
       }
     }),
@@ -102,12 +103,17 @@ export function getPreferredAddressHeaderPair(
  * Gets the associated AddressDetailsType for an address.
  *
  * @param address - The address information associated with a PayID.
+ * @param version - The PayID protocol version.
  * @returns The AddressDetailsType for the address.
  */
 export function getAddressDetailsType(
   address: AddressInformation,
+  version: string,
 ): AddressDetailsType {
   if (address.paymentNetwork === 'ACH') {
+    if (version === '1.0') {
+      return AddressDetailsType.AchAddress
+    }
     return AddressDetailsType.FiatAddress
   }
   return AddressDetailsType.CryptoAddress

--- a/src/types/protocol.ts
+++ b/src/types/protocol.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-inline-comments -- It is useful to have inline comments for interfaces. */
 /**
  * Type of payment address in PaymentInformation.
  */
 export enum AddressDetailsType {
   CryptoAddress = 'CryptoAddressDetails',
-  FiatAddress = 'FiatAddressDetails',
+  FiatAddress = 'FiatAddressDetails', // Replaces AchAddressDetails
+  AchAddress = 'AchAddressDetails', // Maintain compatibility for 1.0
 }
 
 /**

--- a/test/integration/e2e/public-api/basePayId.test.ts
+++ b/test/integration/e2e/public-api/basePayId.test.ts
@@ -134,7 +134,7 @@ describe('E2E - publicAPIRouter - Base PayID', function (): void {
     // WHEN we make a GET request to the public endpoint to retrieve payment info with an Accept header specifying ACH
     request(app.publicApiExpress)
       .get(payId)
-      .set('PayID-Version', '1.0')
+      .set('PayID-Version', '1.1')
       .set('Accept', acceptHeader)
       // THEN we get back our Accept header as the Content-Type
       .expect((res) => {

--- a/test/unit/formatPaymentInfo.test.ts
+++ b/test/unit/formatPaymentInfo.test.ts
@@ -3,6 +3,8 @@ import { assert } from 'chai'
 import { formatPaymentInfo } from '../../src/services/basePayId'
 import { AddressDetailsType } from '../../src/types/protocol'
 
+const version1dot1 = '1.1'
+
 describe('Base PayID - formatPaymentInfo()', function (): void {
   it('Returns CryptoAddressDetails & FiatAddressDetails for addressDetailsTypes when formatting array with multiple AddressInformation', function () {
     // GIVEN an array of AddressInformation with an ACH entry
@@ -48,7 +50,7 @@ describe('Base PayID - formatPaymentInfo()', function (): void {
     }
 
     // WHEN we format it
-    const paymentInfo = formatPaymentInfo(addressInfo, payId)
+    const paymentInfo = formatPaymentInfo(addressInfo, version1dot1, payId)
 
     // THEN we get back a PaymentInformation object with the appropriate address details
     assert.deepStrictEqual(paymentInfo, expectedPaymentInfo)
@@ -80,7 +82,7 @@ describe('Base PayID - formatPaymentInfo()', function (): void {
     }
 
     // WHEN we format it and don't pass in a PayID
-    const paymentInfo = formatPaymentInfo(addressInfo)
+    const paymentInfo = formatPaymentInfo(addressInfo, version1dot1)
 
     // THEN we get back a PaymentInformation object without a PayID
     assert.deepStrictEqual(paymentInfo, expectedPaymentInfo)
@@ -114,7 +116,7 @@ describe('Base PayID - formatPaymentInfo()', function (): void {
     }
 
     // WHEN we format it
-    const paymentInfo = formatPaymentInfo(addressInfo)
+    const paymentInfo = formatPaymentInfo(addressInfo, version1dot1)
 
     // THEN we get back a PaymentInformation object with no environment
     assert.deepStrictEqual(paymentInfo, expectedPaymentInfo)
@@ -153,7 +155,12 @@ describe('Base PayID - formatPaymentInfo()', function (): void {
     const memoFn = (): string => 'memo'
 
     // WHEN we format the address information
-    const paymentInfo = formatPaymentInfo(addressInfo, payId, memoFn)
+    const paymentInfo = formatPaymentInfo(
+      addressInfo,
+      version1dot1,
+      payId,
+      memoFn,
+    )
 
     // THEN we get back a PaymentInformation object with a memo
     assert.deepStrictEqual(paymentInfo, expectedPaymentInfo)

--- a/test/unit/getAddressDetailsType.test.ts
+++ b/test/unit/getAddressDetailsType.test.ts
@@ -3,6 +3,9 @@ import { assert } from 'chai'
 import { getAddressDetailsType } from '../../src/services/basePayId'
 import { AddressDetailsType } from '../../src/types/protocol'
 
+const version1dot0 = '1.0'
+const version1dot1 = '1.1'
+
 describe('Base PayID - getAddressDetailsType()', function (): void {
   it('Returns FiatAddressDetails for addressDetailsType when formatting ACH AddressInformation', function () {
     // GIVEN an array of AddressInformation with a single ACH (empty environment) entry
@@ -16,10 +19,28 @@ describe('Base PayID - getAddressDetailsType()', function (): void {
     }
 
     // WHEN we get the address details type
-    const addressDetailsType = getAddressDetailsType(addressInfo)
+    const addressDetailsType = getAddressDetailsType(addressInfo, version1dot1)
 
     // THEN we get back an AddressDetailsType of FiatAddress
     assert.deepStrictEqual(addressDetailsType, AddressDetailsType.FiatAddress)
+  })
+
+  it('If using version 1.0, returns AchAddressDetails for addressDetailsType when formatting ACH AddressInformation', function () {
+    // GIVEN an array of AddressInformation with a single ACH (empty environment) entry
+    const addressInfo = {
+      paymentNetwork: 'ACH',
+      environment: null,
+      details: {
+        accountNumber: '000123456789',
+        routingNumber: '123456789',
+      },
+    }
+
+    // WHEN we get the address details type
+    const addressDetailsType = getAddressDetailsType(addressInfo, version1dot0)
+
+    // THEN we get back an AddressDetailsType of FiatAddress
+    assert.deepStrictEqual(addressDetailsType, AddressDetailsType.AchAddress)
   })
 
   it('Returns CryptoAddressDetails for addressDetailsType when formatting XRP AddressInformation', function () {
@@ -33,7 +54,7 @@ describe('Base PayID - getAddressDetailsType()', function (): void {
     }
 
     // WHEN we get the address details type
-    const addressDetailsType = getAddressDetailsType(addressInfo)
+    const addressDetailsType = getAddressDetailsType(addressInfo, version1dot1)
 
     // THEN we get back an AddressDetailsType of CryptoAddress
     assert.deepStrictEqual(addressDetailsType, AddressDetailsType.CryptoAddress)


### PR DESCRIPTION
## High Level Overview of Change

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

Updates public API response to intelligently decide on `ACH` vs. `FIAT`
depending on whether the request is a `1.0` or `1.1` response.

Rolls forward the PayID protocol server version to `1.1`.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

Makes ACH -> FIAT `addressDetailsType` change non-breaking.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

We know do some backwards compatibility stuff.

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

I fixed all existing tests, but need to add more test coverage now in a
subsequent PR.

<!--
## Future Tasks
For future tasks related to PR.
-->