### PR TITLE
feat: AdminAPI accepts VerifiedAddresses

### DIFF
--- a/src/data-access/users.ts
+++ b/src/data-access/users.ts
@@ -162,6 +162,7 @@ export async function removeUser(payId: string): Promise<void> {
 
 interface DatabaseAddress extends AddressInformation {
   readonly accountId: string
+  readonly identityKeySignature?: string
 }
 
 /**
@@ -182,6 +183,7 @@ function addAccountIdToAddresses(
     paymentNetwork: address.paymentNetwork.toUpperCase(),
     environment: address.environment?.toUpperCase(),
     details: address.details,
+    identityKeySignature: address.identityKeySignature,
   }))
 }
 

--- a/src/middlewares/users.ts
+++ b/src/middlewares/users.ts
@@ -13,6 +13,7 @@ import {
   replaceUserPayId,
   checkUserExistence,
 } from '../data-access/users'
+import { AddressInformation } from '../types/database'
 import {
   LookupError,
   LookupErrorType,
@@ -113,7 +114,16 @@ export async function postUser(
   // TODO:(hbergren) Need to test here and in `putUser()` that `req.body.addresses` is well formed.
   // This includes making sure that everything that is not ACH or ILP is in a CryptoAddressDetails format.
   // And that we `toUpperCase()` paymentNetwork and environment as part of parsing the addresses.
-  await insertUser(payId, req.body.addresses, req.body.identityKey)
+  let allAddresses: AddressInformation[] = []
+
+  if (req.body.addresses !== undefined) {
+    allAddresses = allAddresses.concat(req.body.addresses)
+  }
+  if (req.body.verifiedAddresses !== undefined) {
+    allAddresses = allAddresses.concat(req.body.verifiedAddresses)
+  }
+
+  await insertUser(payId, allAddresses, req.body.identityKey)
 
   // Set HTTP status and save the PayID to generate the Location header in later middleware
   res.locals.status = HttpStatus.Created

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -34,5 +34,5 @@ export interface Address {
  */
 export type AddressInformation = Pick<
   Address,
-  'paymentNetwork' | 'environment' | 'details'
+  'paymentNetwork' | 'environment' | 'details' | 'identityKeySignature'
 >

--- a/test/integration/e2e/admin-api/postUsers.test.ts
+++ b/test/integration/e2e/admin-api/postUsers.test.ts
@@ -48,6 +48,44 @@ describe('E2E - adminApiRouter - POST /users', function (): void {
       .expect(HttpStatus.Created, done)
   })
 
+  it('Returns a 201 when creating a new user with verifiedAddresses', function (done): void {
+    // GIVEN a user with a PayID known to not exist on the PayID service
+    const userInformation = {
+      payId: 'harrypotter$xpring.money',
+      addresses: [
+        {
+          paymentNetwork: 'BTC',
+          environment: 'TESTNET',
+          details: {
+            address: 'mxNEbRXokcdJtT6sbukr1CTGVx8Tkxk3DB',
+          },
+        },
+      ],
+      verifiedAddresses: [
+        {
+          paymentNetwork: 'XRPL',
+          environment: 'TESTNET',
+          details: {
+            address: 'TVQWr6BhgBLW2jbFyqqufgq8T9eN7KresB684ZSHKQ3oDth',
+          },
+          identityKeySignature:
+            'd2hhdCBhbSBJIGNvZGluZyB3aGF0IGlzIGxpZmUgcGxlYXNlIGhlbHA=',
+        },
+      ],
+    }
+
+    // WHEN we make a POST request to /users with that user information
+    request(app.adminApiExpress)
+      .post(`/users`)
+      .set('PayID-API-Version', payIdApiVersion)
+      .send(userInformation)
+      .expect('Content-Type', /text\/plain/u)
+      // THEN we expect the Location header to be set to the path of the created user resource
+      .expect('Location', `/users/${userInformation.payId}`)
+      // THEN we expect back a 201 - CREATED
+      .expect(HttpStatus.Created, done)
+  })
+
   it('Returns a 201 when creating a new user with an identity key', function (done): void {
     const payId = 'jacksmith$xpring.money'
     const identityKey = `Imp3ayI6IHsKICAia3R5IjogIkVDIiwgCiAgInVzZSI6ICJzaWciL`

--- a/test/integration/e2e/admin-api/postUsers.test.ts
+++ b/test/integration/e2e/admin-api/postUsers.test.ts
@@ -8,6 +8,7 @@ import { appSetup, appCleanup } from '../../../helpers/helpers'
 
 let app: App
 const payIdApiVersion = '2020-05-28'
+const acceptPatch = 'application/merge-patch+json'
 
 describe('E2E - adminApiRouter - POST /users', function (): void {
   before(async function () {
@@ -83,7 +84,17 @@ describe('E2E - adminApiRouter - POST /users', function (): void {
       // THEN we expect the Location header to be set to the path of the created user resource
       .expect('Location', `/users/${userInformation.payId}`)
       // THEN we expect back a 201 - CREATED
-      .expect(HttpStatus.Created, done)
+      .expect(HttpStatus.Created)
+      .end(function () {
+        request(app.adminApiExpress)
+          .get(`/users/${userInformation.payId}`)
+          .set('PayID-API-Version', payIdApiVersion)
+          .expect('Content-Type', /json/u)
+          // THEN we expect to have an Accept-Patch header in the response
+          .expect('Accept-Patch', acceptPatch)
+          // THEN We expect back a 200 - OK, with the account information
+          .expect(HttpStatus.OK, userInformation, done)
+      })
   })
 
   it('Returns a 201 when creating a new user with an identity key', function (done): void {


### PR DESCRIPTION
## High Level Overview of Change

AdminAPI now accepts a POST containing `VerifiedAddresses`.

### Context of Change

https://app.asana.com/0/1182225689526777/1186929984905885

There is one final PR regarding admin api (PUT functionality) for v. payID. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

AdminAPI now accepts verified addresses when posting a user.

## Test Plan

Previous tests continue to work + I added one confirming it gives us a `201` upon posting a user w/ verified addresses.

## Future Tasks

PUT functionality.
-->
