### PR TITLE
Patch API update / fix for V. PayID

### DIFF
--- a/src/middlewares/users.ts
+++ b/src/middlewares/users.ts
@@ -327,6 +327,17 @@ export async function patchUserPayId(
   const newPayId = rawNewPotentialPayId.toLowerCase()
   const oldPayId = rawOldPayId.toLowerCase()
 
+  const verifiedAddresses = await getAllVerifiedAddressInfoFromDatabase(
+    oldPayId,
+  )
+
+  if (verifiedAddresses.length > 0) {
+    throw new ParseError(
+      'Cannot PATCH a PayID with verified addresses, as that would break the address signatures. Please use the PUT endpoint to update this PayID.',
+      ParseErrorType.IncompatibleRequestMethod,
+    )
+  }
+
   const account = await replaceUserPayId(oldPayId, newPayId)
 
   // If we try to update a PayID which doesn't exist, the 'account' object will be null.

--- a/src/routes/publicApiRouter.ts
+++ b/src/routes/publicApiRouter.ts
@@ -18,7 +18,7 @@ publicApiRouter
   // Allow the PayID Protocol to basically ignore CORS
   .use((_req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*')
-    res.header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+    res.header('Access-Control-Allow-Methods', 'GET, OPTIONS')
     res.header('Access-Control-Allow-Headers', 'PayID-Version')
     res.header(
       'Access-Control-Expose-Headers',

--- a/src/utils/errors/parseError.ts
+++ b/src/utils/errors/parseError.ts
@@ -21,6 +21,9 @@ export enum ParseErrorType {
   MissingPayIdApiVersionHeader = 'MissingPayIdApiVersionHeader',
   InvalidPayIdApiVersionHeader = 'InvalidPayIdApiVersionHeader',
   UnsupportedPayIdApiVersionHeader = 'UnsupportedPayIdApiVersionHeader',
+
+  // Verifiable PayID Stuff
+  IncompatibleRequestMethod = 'IncompatibleRequestMethod',
 }
 
 /**

--- a/test/integration/e2e/admin-api/patchUsersPayId.test.ts
+++ b/test/integration/e2e/admin-api/patchUsersPayId.test.ts
@@ -81,6 +81,35 @@ describe('E2E - adminApiRouter - PATCH /users/:payId', function (): void {
       .expect(HttpStatus.Created, done)
   })
 
+  it('Returns a 400 - Bad Request with an error payload for a request changing the PayID on an account with verified addresses', function (done): void {
+    // GIVEN a PayID known to have verified addresses
+    const payId = 'johnwick$127.0.0.1'
+
+    // AND a request to update that PayID to one known to be new
+    const newPayId = {
+      payId: 'bambi$xpring.money',
+    }
+
+    // AND our expected error response
+    const expectedErrorResponse = {
+      error: 'Bad Request',
+      message:
+        'Cannot PATCH a PayID with verified addresses, as that would break the address signatures. Please use the PUT endpoint to update this PayID.',
+      statusCode: 400,
+    }
+
+    // WHEN we make a PATCH request to /users/:payId with the new PayID to update
+    request(app.adminApiExpress)
+      .patch(`/users/${payId}`)
+      .set('PayID-API-Version', payIdApiVersion)
+      .set('Content-Type', contentType)
+      .send(newPayId)
+      .expect('Content-Type', /json/u)
+      .expect('Accept-Patch', contentType)
+      // THEN we expect back a 400 - Bad Request, with the expected error payload response
+      .expect(HttpStatus.BadRequest, expectedErrorResponse, done)
+  })
+
   it('Returns a 400 - Bad Request with an error payload for a request with a malformed PayID', function (done): void {
     // GIVEN a PayID known to be in a bad format (missing $)
     const payId = 'johnnyxpring.money'


### PR DESCRIPTION
## High Level Overview of Change

Fix the PATCH API now that V. PayID exists.

### Context of Change

If you update the PayID of an account that has associated signed addresses, you would break the signatures of those addresses.

So, instead of letting you PATCH the PayID of an account, we now throw an error if any addresses on that account have an associated identity signature.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Added a test for this case, and all tests pass.

<!--
## Future Tasks
For future tasks related to PR.
-->
