### PR TITLE
Log fatal errors when running tests

### DIFF
--- a/src/db/syncDatabaseSchema.ts
+++ b/src/db/syncDatabaseSchema.ts
@@ -72,7 +72,12 @@ async function executeSqlFile(
     // Close the database connection
     await client.end()
   } catch (err) {
-    logger.fatal('error running query', file, err.message)
+    logger.fatal(
+      '\nerror running query',
+      file,
+      err.message,
+      '\n\nCheck that Postgres is running and that there is no port conflict\n',
+    )
 
     // If we can't execute our SQL, our app is in an indeterminate state, so kill it.
     process.exit(1)

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -8,7 +8,7 @@ import logger from '../src/utils/logger'
 // We can use a before block outside any describe block to execute code before any test runs.
 // Here, we disable logging for all tests.
 before(function () {
-  logger.level = 'OFF'
+  logger.level = 'FATAL'
 })
 
 // Close DB connections after all tests are run


### PR DESCRIPTION
## High Level Overview of Change

Currently, all logging is suppressed when tests are run. This is great because logging is too noisy.

However, `FATAL` logs should not occur when everything is going well. But if the tests fail, it is useful to see `FATAL` log output.

This PR sets the log level to `FATAL` during test execution.

### Context of Change

If Postgres is not running or the database does not exist (which can also occur if there is a conflict for Postgres's port, 5432 by default), `npm run test` would fail without any useful log output.

Setting the log level to `FATAL` addresses this. This PR also adds a suggested next step for the particular error that I encountered.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

Note: This is only a new feature for those who run the payid tests (`npm run test`). It has no effect on any other aspect of this project.

## Before / After

Before:
<img width="822" alt="Screen Shot 2020-09-02 at 8 56 09 AM" src="https://user-images.githubusercontent.com/81505/92007033-47df0a00-ecfa-11ea-94f8-f5d95746ee29.png">

After:
<img width="877" alt="Screen Shot 2020-09-02 at 8 56 45 AM" src="https://user-images.githubusercontent.com/81505/92007076-575e5300-ecfa-11ea-8c98-40ad1e91d1ca.png">

## Test Plan

`npm run test` when Postgres is not running or the database does not exist
